### PR TITLE
Fix requestFocus not working on latest flutter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ pubspec.lock
 # Directory created by dartdoc
 # If you don't generate documentation locally you can remove this line.
 doc/api/
+
+
+.idea
+example/ios/Flutter/flutter_export_environment.sh

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -15,7 +15,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     lintOptions {
         disable 'InvalidPackage'
@@ -25,7 +25,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.example"
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,1 +1,2 @@
 org.gradle.jvmargs=-Xmx1536M
+android.enableR8=true

--- a/lib/src/verification_code_input.dart
+++ b/lib/src/verification_code_input.dart
@@ -37,9 +37,7 @@ class _VerificationCodeInputState extends State<VerificationCodeInput> {
   void initState() {
     if (_listFocusNode.isEmpty) {
       for (var i = 0; i < widget.length; i++) {
-        var focusNode = FocusNode();
-        focusNode.canRequestFocus = true;
-        _listFocusNode.add(focusNode);
+        _listFocusNode.add(new FocusNode());
         _listControllerText.add(new TextEditingController());
         _code.add(' ');
       }

--- a/lib/src/verification_code_input.dart
+++ b/lib/src/verification_code_input.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 
 class VerificationCodeInput extends StatefulWidget {
   final ValueChanged<String> onCompleted;
@@ -36,7 +37,9 @@ class _VerificationCodeInputState extends State<VerificationCodeInput> {
   void initState() {
     if (_listFocusNode.isEmpty) {
       for (var i = 0; i < widget.length; i++) {
-        _listFocusNode.add(new FocusNode());
+        var focusNode = FocusNode();
+        focusNode.canRequestFocus = true;
+        _listFocusNode.add(focusNode);
         _listControllerText.add(new TextEditingController());
         _code.add(' ');
       }
@@ -118,7 +121,9 @@ class _VerificationCodeInputState extends State<VerificationCodeInput> {
       setState(() {
         _currentIdex = index + 1;
       });
-      FocusScope.of(context).requestFocus(_listFocusNode[index + 1]);
+      SchedulerBinding.instance.addPostFrameCallback((_) {
+        FocusScope.of(context).requestFocus(_listFocusNode[index + 1]);
+      });
     }
   }
 
@@ -130,7 +135,9 @@ class _VerificationCodeInputState extends State<VerificationCodeInput> {
         }
         _currentIdex = index - 1;
       });
-      FocusScope.of(context).requestFocus(_listFocusNode[index - 1]);
+      SchedulerBinding.instance.addPostFrameCallback((_) {
+        FocusScope.of(context).requestFocus(_listFocusNode[index - 1]);
+      });
     }
   }
 


### PR DESCRIPTION
On Flutter v1.12,  after insert a number, the keyboard will be dismissed. I don't know exactly which change in flutter causes this issue, but if we delay the `requestFocus` to next frame then it will work.